### PR TITLE
Add support for after-response handler callback

### DIFF
--- a/lib/fluffle/handlers/base.rb
+++ b/lib/fluffle/handlers/base.rb
@@ -7,9 +7,9 @@ module Fluffle
 
       # This is called *after* the server has published the response message
       # to the client's queue.
-      def after_response(request:)
-        nil
-      end
+      # def after_response(request:)
+      #   ...
+      # end
     end
   end
 end

--- a/lib/fluffle/handlers/base.rb
+++ b/lib/fluffle/handlers/base.rb
@@ -4,6 +4,12 @@ module Fluffle
       def call(method:, params:, id:, meta:)
         raise RuntimeError, '#call is not implemented on abstract Base handler class'
       end
+
+      # This is called *after* the server has published the response message
+      # to the client's queue.
+      def after_response(request:)
+        nil
+      end
     end
   end
 end

--- a/lib/fluffle/server.rb
+++ b/lib/fluffle/server.rb
@@ -163,6 +163,10 @@ module Fluffle
         @exchange.publish Oj.dump(response), routing_key: reply_to,
                                              correlation_id: response['id']
       end
+
+      if handler.respond_to? :after_response
+        handler.after_response request: request
+      end
     end
 
     # handler - Instance of a `Handler` that may receive `#call`

--- a/lib/fluffle/server.rb
+++ b/lib/fluffle/server.rb
@@ -165,7 +165,11 @@ module Fluffle
       end
 
       if handler.respond_to? :after_response
-        handler.after_response request: request
+        begin
+          handler.after_response request: request
+        rescue => err
+          log_error(err) if Fluffle.logger.error?
+        end
       end
     end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -128,5 +128,23 @@ describe Fluffle::Server do
         expect(meta['handler_duration']).to be >= 0.01
       end
     end
+
+    it "calls the handler's #after_response method if defined" do
+      @params = ['foo']
+
+      result = 'bar'
+      handler = double 'Handler'
+      expect(handler).to receive(:call).ordered.and_return(result)
+
+      expect(handler).to receive(:after_response).ordered do |opts|
+        expect(opts[:request]).to include({
+          'params' => @params,
+        })
+      end
+
+      make_request handler: handler
+
+      expect_response payload: { 'result' => result }
+    end
   end
 end


### PR DESCRIPTION
This is so that handlers can run code between handling requests without introducing latency to the critical path of request handling.